### PR TITLE
Fix session assignment fallback

### DIFF
--- a/lib/htmlgrid/composite.rb
+++ b/lib/htmlgrid/composite.rb
@@ -51,6 +51,21 @@ module HtmlGrid
 		CSS_ID = nil
 		DEFAULT_CLASS = Value
 		LOOKANDFEEL_MAP = {}
+
+    def self.component(klass, key, name=nil)
+      methname = klass.to_s.downcase.gsub('::', '_') << '_' << key.to_s
+      define_method(methname) { |*args|
+        model, session = args
+        args = [model.send(key), session || @session, self]
+        if(name)
+          args.unshift(name)
+          lookandfeel_map.store(methname.to_sym, name.to_sym)
+        end
+        klass.new(*args)
+      }
+      methname.to_sym
+    end
+
 		def init
 			super
 			setup_grid()
@@ -101,19 +116,6 @@ module HtmlGrid
 		end
 		def symbol_map
 			@symbol_map ||= self::class::SYMBOL_MAP.dup
-		end
-		def AbstractComposite.component(klass, key, name=nil)
-			methname = klass.to_s.downcase.gsub('::', '_') << '_' << key.to_s
-			define_method(methname) { |*args|
-				model, session = args
-				args = [model.send(key), session, self]
-				if(name)
-					args.unshift(name)
-					lookandfeel_map.store(methname.to_sym, name.to_sym)
-				end
-				klass.new(*args)
-			}
-			methname.to_sym
 		end
 	end
 	class TagComposite < AbstractComposite

--- a/test/test_composite.rb
+++ b/test/test_composite.rb
@@ -88,6 +88,9 @@ module CompositeTest
     public :labels?
   end
   class StubCompositeModel
+    def qux
+      'qux'
+    end
   end
   class StubCompositeLookandfeel
     def event_url(one)
@@ -109,6 +112,9 @@ module CompositeTest
     def error(key)
     end
   end
+
+  class StubCompositeSession2 < StubCompositeSession; end
+
   class StubCompositeForm < HtmlGrid::Form
     COMPONENTS = {
       [0, 0] => StubComposite
@@ -141,6 +147,23 @@ module CompositeTest
       @composite = StubComposite.new(
         StubCompositeModel.new, StubCompositeSession.new)
     end
+
+    def test_component_session_fallback_assignment_without_session_argment
+      StubComposite.component(StubComposite, :qux)
+      model    = StubCompositeModel.new
+      session1 = StubCompositeSession.new
+      composite = StubComposite.new(model, session1)
+      # via instance variable (without argument)
+      composite = composite.compositetest_stubcomposite_qux(model)
+      assert_kind_of(StubCompositeSession, composite.session)
+      assert_equal(session1, composite.session)
+      # via argument
+      session2 = StubCompositeSession2.new
+      composite = composite.compositetest_stubcomposite_qux(model, session2)
+      assert_kind_of(StubCompositeSession2, composite.session)
+      assert_equal(session2, composite.session)
+    end
+
     def test_create_method
       foo = nil
       foo = @composite.create(:foo, @composite.model)


### PR DESCRIPTION
Add support session assignment fallback at component creation.
Fix session variable to be assigned as argument.
